### PR TITLE
fix build with g++ 14

### DIFF
--- a/devices/airspy-handler/airspy-handler.cpp
+++ b/devices/airspy-handler/airspy-handler.cpp
@@ -36,6 +36,9 @@
 
 #include "constants.h"
 #include "airspy-handler.h"
+
+#include <climits>
+
 #include "logging.h"
 #include "math-helper.h"
 #include <inttypes.h>

--- a/devices/rtlsdr-handler/rtlsdr-handler.h
+++ b/devices/rtlsdr-handler/rtlsdr-handler.h
@@ -27,6 +27,7 @@
 #ifndef RTLSDR_HANDLER_H
 #define	RTLSDR_HANDLER_H
 
+#include <climits>
 #include <stdio.h>
 #include "constants.h"
 #include "device-handler.h"

--- a/devices/sdrplay-handler-v3/sdrplay-handler-v3.cpp
+++ b/devices/sdrplay-handler-v3/sdrplay-handler-v3.cpp
@@ -24,6 +24,9 @@
  *    Lazy Chair Computing
  */
 #include "sdrplay-handler-v3.h"
+
+#include <climits>
+
 #include "constants.h"
 #include "logging.h"
 

--- a/devices/sdrplay-handler/sdrplay-handler.cpp
+++ b/devices/sdrplay-handler/sdrplay-handler.cpp
@@ -25,6 +25,9 @@
  */
 
 #include "sdrplay-handler.h"
+
+#include <climits>
+
 #include "logging.h"
 
 #define DEV_PLAY LOG_DEV


### PR DESCRIPTION
now with just the climit includes, needed for INT_MAX and similar macros